### PR TITLE
Fix docker build error

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,10 @@ RUN git clone -b ${CLONE_TAG} --depth 1 https://github.com/BVLC/caffe.git .
 
 COPY ./source/extract_nfeatures.cpp  ${CAFFE_ROOT}/tools
 
-RUN pip install --upgrade pip && \
+# FYI: Python 2 is no longer supported since pip 21.0.
+# https://stackoverflow.com/questions/65869296/installing-pip-is-not-working-in-python-3-6/65871131#65871131
+# https://pip.pypa.io/en/stable/news/#id1
+RUN pip install --upgrade "pip < 21.0"  && \
     cd python && for req in $(cat requirements.txt) pydot; do pip install $req; done && cd .. && \
     mkdir build && cd build && \
     cmake -DCPU_ONLY=1 .. && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:16.04
-LABEL maintainer minet6759@gmail.com
+LABEL maintainer chikazawa0517@gmail.com
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \


### PR DESCRIPTION
## WHAT
The cause of the docker build error was that pip no longer supports python 2.7.

https://pip.pypa.io/en/stable/news/#v20-1
https://stackoverflow.com/questions/65869296/installing-pip-is-not-working-in-python-3-6/65871131#65871131